### PR TITLE
bump(deps): Update supported Node.js versions to 18, 20, 21

### DIFF
--- a/.github/workflows/build-node.yaml
+++ b/.github/workflows/build-node.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x,20.x,21.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x,20.x,21.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Work in progress.
Fixes #27 