### PR TITLE
fix: Handle unpatched console methods

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -18,7 +18,15 @@ const sessions = {};
 console = {};
 Object.keys(consoleHolder).forEach(method => {
   console[method] = (...args) => {
-    BSTestOpsPatcher[method](...args);
+    try {
+      if (!Object.keys(BSTestOpsPatcher).includes(method)) {
+        consoleHolder[method](...args);
+      } else {
+        BSTestOpsPatcher[method](...args);
+      }
+    } catch (error) {
+      consoleHolder[method](...args);
+    }
   };
 });
 


### PR DESCRIPTION
Some of the console methods are not patched, and thus it fails when these are invoked. This PR aims to fix this issue by invoking the original console methods