### PR TITLE
SDK-667 : Limit VCS info to 64kb

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -20,9 +20,9 @@ exports.EVENTS = {
 exports.ACCESSIBILITY_URL= 'https://accessibility.browserstack.com/api';
 
 // Maximum size of VCS info which is allowed
-exports.MAX_GIT_META_DATA_SIZE_IN_KB = 64;
+exports.MAX_GIT_META_DATA_SIZE_IN_BYTES = 65536;
 
 /* The value to be appended at the end if git metadata is larger than
-MAX_GIT_META_DATA_SIZE_IN_KB
+MAX_GIT_META_DATA_SIZE_IN_BYTES
 */
 exports.GIT_META_DATA_TRUNCATED = '...[TRUNCATED]';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -20,7 +20,7 @@ exports.EVENTS = {
 exports.ACCESSIBILITY_URL= 'https://accessibility.browserstack.com/api';
 
 // Maximum size of VCS info which is allowed
-exports.MAX_GIT_META_DATA_SIZE_IN_BYTES = 65536;
+exports.MAX_GIT_META_DATA_SIZE_IN_BYTES = 64 * 1024;
 
 /* The value to be appended at the end if git metadata is larger than
 MAX_GIT_META_DATA_SIZE_IN_BYTES

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -18,3 +18,11 @@ exports.EVENTS = {
   SCREENSHOT: 'testObservability:screenshot'
 };
 exports.ACCESSIBILITY_URL= 'https://accessibility.browserstack.com/api';
+
+// Maximum size of VCS info which is allowed
+exports.MAX_GIT_META_DATA_SIZE_IN_KB = 64;
+
+/* The value to be appended at the end if git metadata is larger than
+MAX_GIT_META_DATA_SIZE_IN_KB
+*/
+exports.GIT_META_DATA_TRUNCATED = '...[TRUNCATED]';

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -8,7 +8,8 @@ const gitconfig = require('gitconfiglocal');
 const pGitconfig = promisify(gitconfig);
 const gitLastCommit = require('git-last-commit');
 const {makeRequest} = require('./requestHelper');
-const {RERUN_FILE, DEFAULT_WAIT_TIMEOUT_FOR_PENDING_UPLOADS, DEFAULT_WAIT_INTERVAL_FOR_PENDING_UPLOADS, consoleHolder} = require('./constants');
+const {RERUN_FILE, DEFAULT_WAIT_TIMEOUT_FOR_PENDING_UPLOADS, DEFAULT_WAIT_INTERVAL_FOR_PENDING_UPLOADS, consoleHolder,
+  MAX_GIT_META_DATA_SIZE_IN_KB, GIT_META_DATA_TRUNCATED} = require('./constants');
 const requestQueueHandler = require('./requestQueueHandler');
 const Logger = require('./logger');
 const LogPatcher = require('./logPatcher');
@@ -403,7 +404,7 @@ exports.getGitMetaData = () => {
             const {remote} = await pGitconfig(info.commonGitDir);
             const remotes = Object.keys(remote).map(remoteName =>  ({name: remoteName, url: remote[remoteName]['url']}));
 
-            resolve({
+            let gitMetaData = {
               'name': 'git',
               'sha': info['sha'],
               'short_sha': info['abbreviatedSha'],
@@ -420,13 +421,17 @@ exports.getGitMetaData = () => {
               'last_tag': info['lastTag'],
               'commits_since_last_tag': info['commitsSinceLastTag'],
               'remotes': remotes
-            });
+            };
+
+            gitMetaData = this.checkAndTruncateVCSInfo(gitMetaData);
+
+            resolve(gitMetaData);
           }, {dst: await findGitConfig(process.cwd())});
         } else {
           const {remote} = await pGitconfig(info.commonGitDir);
           const remotes = Object.keys(remote).map(remoteName =>  ({name: remoteName, url: remote[remoteName]['url']}));
 
-          resolve({
+          let gitMetaData = {
             'name': 'git',
             'sha': info['sha'],
             'short_sha': info['abbreviatedSha'],
@@ -443,7 +448,11 @@ exports.getGitMetaData = () => {
             'last_tag': info['lastTag'],
             'commits_since_last_tag': info['commitsSinceLastTag'],
             'remotes': remotes
-          });
+          };
+
+          gitMetaData = this.checkAndTruncateVCSInfo(gitMetaData);
+
+          resolve(gitMetaData);
         }
       } catch (err) {
         Logger.error(`Exception in populating Git metadata with error : ${err}`);
@@ -762,4 +771,50 @@ exports.deepClone = (obj) => {
 
 exports.shouldSendLogs = () => {
   return exports.isTestObservabilitySession() && exports.isCucumberTestSuite();
+};
+
+exports.checkAndTruncateVCSInfo = (gitMetaData) => {
+  const gitMetaDataSizeInKb = this.getSizeOfJsonObjectInKb(gitMetaData);
+
+  if (gitMetaDataSizeInKb && gitMetaDataSizeInKb > 0 && gitMetaDataSizeInKb > MAX_GIT_META_DATA_SIZE_IN_KB) {
+    const truncateSize = gitMetaDataSizeInKb - MAX_GIT_META_DATA_SIZE_IN_KB;
+    const truncatedCommitMessage = this.truncateString(gitMetaData.commit_message, truncateSize);
+    gitMetaData.commit_message = truncatedCommitMessage;
+    Logger.debug('The commit has been truncated');
+  }
+
+  return gitMetaData;
+};
+
+exports.getSizeOfJsonObjectInKb = (jsonData) => {
+  try {
+    if (jsonData) {
+      const buffer = Buffer.from(JSON.stringify(jsonData));
+
+      return Math.floor(buffer.length/1024);
+    }
+  } catch (error) {
+    Logger.debug(`Something went wrong while calculating size of JSON object: ${error}`);
+  }
+
+  return -1;
+};
+
+exports.truncateString = (field, truncateSizeInKb) => {
+  try {
+    const bufferSizeInBytes = Buffer.from(GIT_META_DATA_TRUNCATED).length;
+
+    const fieldBufferObj = Buffer.from(field);
+    const lenOfFieldBufferObj = fieldBufferObj.length;
+    const finalLen = Math.round(lenOfFieldBufferObj - (truncateSizeInKb * 1024) - (bufferSizeInBytes));
+    if (finalLen > 0) {
+      const truncatedString = fieldBufferObj.subarray(0, finalLen).toString() + GIT_META_DATA_TRUNCATED;
+
+      return truncatedString;
+    }
+  } catch (error) {
+    Logger.debug(`Error while truncating field, nothing was truncated here: ${error}`);
+  }
+
+  return field;
 };

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -780,7 +780,7 @@ exports.checkAndTruncateVCSInfo = (gitMetaData) => {
     const truncateSize = gitMetaDataSizeInKb - MAX_GIT_META_DATA_SIZE_IN_KB;
     const truncatedCommitMessage = this.truncateString(gitMetaData.commit_message, truncateSize);
     gitMetaData.commit_message = truncatedCommitMessage;
-    Logger.debug('The commit has been truncated');
+    Logger.info(`The commit has been truncated. Size of commit after truncation is ${ this.getSizeOfJsonObjectInKb(gitMetaData) }`);
   }
 
   return gitMetaData;
@@ -788,7 +788,7 @@ exports.checkAndTruncateVCSInfo = (gitMetaData) => {
 
 exports.getSizeOfJsonObjectInKb = (jsonData) => {
   try {
-    if (jsonData) {
+    if (jsonData && jsonData instanceof Object) {
       const buffer = Buffer.from(JSON.stringify(jsonData));
 
       return Math.floor(buffer.length/1024);


### PR DESCRIPTION
Limiting the total size of VCS info to 64 Kb.

JIRA: https://browserstack.atlassian.net/browse/SDK-667

PR approved on fork branch : https://github.com/TamsilAmani/nightwatch-plugin-browserstack/pull/1