### PR TITLE
feat: add setCustomTag API for custom test metadata

### DIFF
--- a/.github/dev-guide/local-testing.md
+++ b/.github/dev-guide/local-testing.md
@@ -1,0 +1,111 @@
+# Local Testing Guide (Nightwatch Plugin)
+
+> Pack, link, and run the local nightwatch-plugin-browserstack against a sample project to verify changes.
+
+---
+
+## Prerequisites
+
+- **Node.js:** 16+ recommended
+- **Sample repo:** A Nightwatch project that uses `@nightwatch/browserstack` (e.g., `nightwatch-browserstack`)
+- **BrowserStack credentials:** `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` exported in your shell
+
+---
+
+## Build (Pack)
+
+```bash
+cd /absolute/path/to/nightwatch-plugin-browserstack
+
+# Remove any previous tarball first — avoids installing a stale version
+rm -f nightwatch-browserstack-*.tgz
+
+npm pack
+# → nightwatch-browserstack-<version>.tgz (e.g., nightwatch-browserstack-3.8.0.tgz)
+
+# Capture the tarball path
+export NW_PLUGIN_TGZ=$(pwd)/$(ls nightwatch-browserstack-*.tgz | head -1)
+echo "Tarball: $NW_PLUGIN_TGZ"
+```
+
+---
+
+## Link to Sample
+
+Install the local tarball directly into the sample project:
+
+```bash
+cd /absolute/path/to/<sample>
+
+npm install "$NW_PLUGIN_TGZ"
+```
+
+Verify the linked version has your changes:
+
+```bash
+# Check the installed version
+cat node_modules/@nightwatch/browserstack/package.json | grep version
+```
+
+> **Tip:** When iterating on changes, always delete the old `.tgz` before repacking:
+> ```bash
+> cd /absolute/path/to/nightwatch-plugin-browserstack
+> rm -f nightwatch-browserstack-*.tgz
+> npm pack
+> cd /absolute/path/to/<sample>
+> npm install "$NW_PLUGIN_TGZ"
+> ```
+
+---
+
+## Run Sample
+
+> **Working directory:** Run all test commands from the **sample's root directory**, not the plugin directory.
+
+```bash
+cd /absolute/path/to/<sample>
+
+# Export credentials if not already set
+export BROWSERSTACK_USERNAME=<your-username>
+export BROWSERSTACK_ACCESS_KEY=<your-access-key>
+
+# Run a single test
+npx nightwatch --test ./tests/single/single_test.js --env browserstack 2>&1 | tee /tmp/nw-test-run.log
+```
+
+After the run, verify:
+```bash
+# Check for BrowserStack signals and errors
+grep -i "browserstack\|bstack\|error\|exception" /tmp/nw-test-run.log | head -30
+```
+
+---
+
+## Troubleshooting
+
+### "Still using published version, not local"
+```bash
+# Verify the installed version matches your tarball
+cat <sample>/node_modules/@nightwatch/browserstack/package.json | grep version
+
+# If stale, reinstall
+cd <sample> && npm install "$NW_PLUGIN_TGZ"
+```
+
+### "Cannot convert undefined or null to object" in `helper.js:checkTestEnvironmentForAppAutomate`
+The nightwatch version in the sample may be too old. The plugin 3.x requires nightwatch 3.x:
+```bash
+npx nightwatch --version
+# If 2.x, upgrade:
+npm install nightwatch@latest
+```
+
+### "TypeError: browser.<method> is not a function"
+The plugin was not correctly linked. Re-pack and reinstall:
+```bash
+cd /absolute/path/to/nightwatch-plugin-browserstack
+rm -f nightwatch-browserstack-*.tgz
+npm pack
+cd /absolute/path/to/<sample>
+npm install /absolute/path/to/nightwatch-plugin-browserstack/nightwatch-browserstack-*.tgz
+```

--- a/nightwatch/globals.js
+++ b/nightwatch/globals.js
@@ -502,7 +502,8 @@ module.exports = {
         // Aggregate build-level custom tags from worker processes
         try {
           const tmpDir = os.tmpdir();
-          const tagFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('bstack_build_tags_') && f.endsWith('.json'));
+          const runId = process.env.BROWSERSTACK_TESTHUB_UUID || process.pid;
+          const tagFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith(`bstack_build_tags_${runId}_`) && f.endsWith('.json'));
           for (const tagFile of tagFiles) {
             const filePath = path.join(tmpDir, tagFile);
             try {
@@ -607,7 +608,8 @@ module.exports = {
         }
         // Also write to temp file for standard Nightwatch parallel where
         // we don't have a direct IPC listener in the parent
-        const tagFile = path.join(os.tmpdir(), `bstack_build_tags_${process.pid}.json`);
+        const runId = process.env.BROWSERSTACK_TESTHUB_UUID || process.pid;
+        const tagFile = path.join(os.tmpdir(), `bstack_build_tags_${runId}_${process.pid}.json`);
         fs.writeFileSync(tagFile, JSON.stringify(buildTags));
       }
     } catch (err) {

--- a/nightwatch/globals.js
+++ b/nightwatch/globals.js
@@ -10,6 +10,7 @@ const AccessibilityAutomation = require('../src/accessibilityAutomation');
 const eventHelper = require('../src/utils/eventHelper');
 const OrchestrationUtils = require('../src/testorchestration/orchestrationUtils');
 const TestMap = require('../src/utils/testMap');
+const CustomTagManager = require('../src/utils/customTagManager');
 const localTunnel = new LocalTunnel();
 const testObservability = new TestObservability();
 const accessibilityAutomation = new AccessibilityAutomation();
@@ -499,6 +500,10 @@ module.exports = {
       browser.getAccessibilityResultsSummary = () => { return accessibilityAutomation.getAccessibilityResultsSummary() };
     }
     // await accessibilityAutomation.beforeEachExecution(browser);
+
+    browser.setCustomTag = (keyName, keyValue, buildLevelCustomTag) => {
+      CustomTagManager.setCustomTag(keyName, keyValue, buildLevelCustomTag || false, process.env.TEST_RUN_UUID);
+    };
   },
 
   // This will be run after each test suite is finished

--- a/nightwatch/globals.js
+++ b/nightwatch/globals.js
@@ -6,6 +6,8 @@ const helper = require('../src/utils/helper');
 const Logger = require('../src/utils/logger');
 const {v4: uuidv4} = require('uuid');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 const AccessibilityAutomation = require('../src/accessibilityAutomation');
 const eventHelper = require('../src/utils/eventHelper');
 const OrchestrationUtils = require('../src/testorchestration/orchestrationUtils');
@@ -100,6 +102,14 @@ module.exports = {
 
         Object.values(workerList).forEach((worker) => {
           worker.process.on('message', async (data) => {
+            if (data.BUILD_LEVEL_CUSTOM_TAGS) {
+              try {
+                const tags = JSON.parse(data.BUILD_LEVEL_CUSTOM_TAGS);
+                CustomTagManager.mergeBuildLevelTags(tags);
+              } catch (err) {
+                Logger.debug(`Error merging build-level tags from worker: ${err}`);
+              }
+            }
             if (data.POST_SESSION_EVENT) {
               helper.storeSessionsData(data);
             }
@@ -152,6 +162,7 @@ module.exports = {
         if (testMetaData) {
           delete _tests[testCaseId];
           testMetaData.finishedAt = new Date().toISOString();
+          CustomTagManager.drainPendingTestTags(testMetaData.uuid);
           await testObservability.sendTestRunEventForCucumber(reportData, gherkinDocument, pickleData, 'TestRunFinished', testMetaData, args);
         }
       } catch (error) {
@@ -280,8 +291,15 @@ module.exports = {
       try {
         await accessibilityAutomation.afterEachExecution(test, uuid);
         if (testRunner !== 'cucumber'){
+          // Drain pending tags synchronously before the async sendTestRunEvent,
+          // to avoid races where the next test's tags leak into pendingTestTags
+          // and get drained into the wrong UUID.
+          CustomTagManager.drainPendingTestTags(uuid);
           testEventPromises.push(testObservability.sendTestRunEvent('TestRunFinished', test, uuid));
           TestMap.markTestFinished(uuid);
+          // Clear UUID so the next test's setCustomTag calls buffer to pendingTestTags
+          // (test body runs before TestRunStarted assigns the new UUID)
+          delete process.env.TEST_RUN_UUID;
         }
         
       } catch (error) {
@@ -480,6 +498,25 @@ module.exports = {
           await Promise.all(testEventPromises);
           testEventPromises.length = 0; // Clear the array
         }
+
+        // Aggregate build-level custom tags from worker processes
+        try {
+          const tmpDir = os.tmpdir();
+          const tagFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('bstack_build_tags_') && f.endsWith('.json'));
+          for (const tagFile of tagFiles) {
+            const filePath = path.join(tmpDir, tagFile);
+            try {
+              const tags = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              CustomTagManager.mergeBuildLevelTags(tags);
+              fs.unlinkSync(filePath);
+            } catch (err) {
+              Logger.debug(`Error reading build-level tags file ${tagFile}: ${err}`);
+            }
+          }
+        } catch (err) {
+          Logger.debug(`Error aggregating build-level tags from workers: ${err}`);
+        }
+
         await testObservability.stopBuildUpstream();
         if (process.env.BROWSERSTACK_TESTHUB_UUID) {
           Logger.info(`\nVisit https://automation.browserstack.com/builds/${process.env.BROWSERSTACK_TESTHUB_UUID} to view build report, insights, and many more debugging information all at one place!\n`);
@@ -500,6 +537,9 @@ module.exports = {
       browser.getAccessibilityResultsSummary = () => { return accessibilityAutomation.getAccessibilityResultsSummary() };
     }
     // await accessibilityAutomation.beforeEachExecution(browser);
+
+    // Clear stale UUID so tags go to pendingTestTags until TestRunStarted assigns the new UUID
+    delete process.env.TEST_RUN_UUID;
 
     browser.setCustomTag = (keyName, keyValue, buildLevelCustomTag) => {
       CustomTagManager.setCustomTag(keyName, keyValue, buildLevelCustomTag || false, process.env.TEST_RUN_UUID);
@@ -556,6 +596,23 @@ module.exports = {
   },
 
   async afterChildProcess() {
+
+    // Send build-level custom tags from worker to parent process
+    try {
+      const buildTags = CustomTagManager.getBuildLevelCustomMetadata();
+      if (buildTags && Object.keys(buildTags).length > 0) {
+        if (process.send) {
+          // Cucumber parallel: send via IPC directly
+          process.send({BUILD_LEVEL_CUSTOM_TAGS: JSON.stringify(buildTags)});
+        }
+        // Also write to temp file for standard Nightwatch parallel where
+        // we don't have a direct IPC listener in the parent
+        const tagFile = path.join(os.tmpdir(), `bstack_build_tags_${process.pid}.json`);
+        fs.writeFileSync(tagFile, JSON.stringify(buildTags));
+      }
+    } catch (err) {
+      Logger.debug(`Error sending build-level tags from worker: ${err}`);
+    }
 
     await helper.shutDownRequestHandler();
     if (testEventPromises.length > 0) {

--- a/src/testObservability.js
+++ b/src/testObservability.js
@@ -12,6 +12,7 @@ const OrchestrationUtils = require('./testorchestration/orchestrationUtils');
 const AccessibilityAutomation = require('./accessibilityAutomation');
 const accessibilityScripts = require('./scripts/accessibilityScripts');
 const TestMap = require('./utils/testMap');
+const CustomTagManager = require('./utils/customTagManager');
 const hooksMap = {};
 const accessibilityAutomation = new AccessibilityAutomation();
 
@@ -265,6 +266,10 @@ class TestObservability {
     const data = {
       'finished_at': new Date().toISOString()
     };
+    const buildCustomMetadata = CustomTagManager.getBuildLevelCustomMetadata();
+    if (buildCustomMetadata && Object.keys(buildCustomMetadata).length > 0) {
+      data.custom_metadata = buildCustomMetadata;
+    }
     const config = {
       headers: {
         'Authorization': `Bearer ${process.env.BROWSERSTACK_TESTHUB_JWT}`,
@@ -523,6 +528,15 @@ class TestObservability {
       await this.processTestRunData (eventData, uuid);
     }
 
+    const customMetadata = CustomTagManager.getTestLevelCustomMetadata(uuid);
+    if (customMetadata && Object.keys(customMetadata).length > 0) {
+      testData.custom_metadata = customMetadata;
+    }
+
+    if (eventType === 'TestRunFinished') {
+      CustomTagManager.clearTestLevelCustomMetadata(uuid);
+    }
+
     const uploadData = {
       event_type: eventType,
       test_run: testData
@@ -683,6 +697,15 @@ class TestObservability {
         testData.hooks = hooksList;
         this.updateTestStatus(args, testData);
       }
+    }
+
+    const cucumberCustomMetadata = CustomTagManager.getTestLevelCustomMetadata(uuid);
+    if (cucumberCustomMetadata && Object.keys(cucumberCustomMetadata).length > 0) {
+      testData.custom_metadata = cucumberCustomMetadata;
+    }
+
+    if (eventType === 'TestRunFinished') {
+      CustomTagManager.clearTestLevelCustomMetadata(uuid);
     }
 
     const uploadData = {

--- a/src/utils/customTagManager.js
+++ b/src/utils/customTagManager.js
@@ -154,4 +154,4 @@ exports.mergeBuildLevelTags = function(tags) {
 exports._splitValues = splitValues;
 exports._testLevelTags = testLevelTags;
 exports._buildLevelTags = buildLevelTags;
-exports._getPendingTestTags = function() { return pendingTestTags; };
+exports._getPendingTestTags = function() { return pendingTestTags };

--- a/src/utils/customTagManager.js
+++ b/src/utils/customTagManager.js
@@ -26,7 +26,7 @@ let pendingTestTags = {};
  */
 function splitValues(input) {
   const result = [];
-  const regex = /"([^"]*)"|[^,]+/g;
+  const regex = /\s*"([^"]*)"\s*|[^,]+/g;
   let match;
   while ((match = regex.exec(input)) !== null) {
     const value = match[1] !== undefined ? match[1] : match[0].trim();
@@ -99,9 +99,17 @@ exports.setCustomTag = function(keyName, keyValue, buildLevelCustomTag, testUUID
 
 /**
  * Returns the custom metadata object for a specific test UUID.
- * Also drains any pendingTestTags into this UUID's entry.
  */
 exports.getTestLevelCustomMetadata = function(uuid) {
+  return testLevelTags.get(uuid) || {};
+};
+
+/**
+ * Drains pendingTestTags into the specified UUID's entry.
+ * Must be called synchronously when the UUID is known and before any async
+ * processing, to avoid races with the next test buffering into pendingTestTags.
+ */
+exports.drainPendingTestTags = function(uuid) {
   if (uuid && Object.keys(pendingTestTags).length > 0) {
     if (!testLevelTags.has(uuid)) {
       testLevelTags.set(uuid, {});
@@ -109,8 +117,6 @@ exports.getTestLevelCustomMetadata = function(uuid) {
     mergeAll(testLevelTags.get(uuid), pendingTestTags);
     pendingTestTags = {};
   }
-
-  return testLevelTags.get(uuid) || {};
 };
 
 /**
@@ -125,6 +131,21 @@ exports.getBuildLevelCustomMetadata = function() {
  */
 exports.clearTestLevelCustomMetadata = function(uuid) {
   testLevelTags.delete(uuid);
+};
+
+/**
+ * Merges external build-level tags into the local buildLevelTags.
+ * Used to aggregate tags received from worker processes via IPC.
+ */
+exports.mergeBuildLevelTags = function(tags) {
+  if (!tags || typeof tags !== 'object') {
+    return;
+  }
+  for (const [keyName, entry] of Object.entries(tags)) {
+    if (entry && Array.isArray(entry.values)) {
+      mergeInto(buildLevelTags, keyName, entry.values);
+    }
+  }
 };
 
 // Exported for testing

--- a/src/utils/customTagManager.js
+++ b/src/utils/customTagManager.js
@@ -1,0 +1,134 @@
+const Logger = require('./logger');
+
+/**
+ * CustomTagManager manages custom tag metadata at both test and build levels.
+ *
+ * Each tag entry is structured as:
+ *   { field_type: "multi_dropdown", values: ["val1", "val2"] }
+ *
+ * When the same key is set multiple times, values are merged (not overridden).
+ */
+
+// Per-test custom metadata keyed by test UUID
+const testLevelTags = new Map();
+
+// Build-level custom metadata (single object)
+const buildLevelTags = {};
+
+// Buffer for test-level tags set before UUID is available.
+// Drained into the correct UUID entry when getTestLevelCustomMetadata is called.
+let pendingTestTags = {};
+
+/**
+ * Splits a comma-separated string into an array of trimmed values.
+ * Handles quoted strings containing commas.
+ * e.g. '"a,b", c' -> ["a,b", "c"]
+ */
+function splitValues(input) {
+  const result = [];
+  const regex = /"([^"]*)"|[^,]+/g;
+  let match;
+  while ((match = regex.exec(input)) !== null) {
+    const value = match[1] !== undefined ? match[1] : match[0].trim();
+    if (value !== '') {
+      result.push(value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Merges new values into an existing tag entry, deduplicating.
+ */
+function mergeInto(target, keyName, newValues) {
+  if (target[keyName]) {
+    const existing = target[keyName].values;
+    for (const val of newValues) {
+      if (!existing.includes(val)) {
+        existing.push(val);
+      }
+    }
+  } else {
+    target[keyName] = {field_type: 'multi_dropdown', values: [...newValues]};
+  }
+}
+
+/**
+ * Merges all entries from source into target.
+ */
+function mergeAll(target, source) {
+  for (const [keyName, entry] of Object.entries(source)) {
+    mergeInto(target, keyName, entry.values);
+  }
+}
+
+/**
+ * Sets a custom tag. If buildLevelCustomTag is true, stores at build level.
+ * Otherwise stores at test level keyed by testUUID.
+ * If testUUID is not yet available, buffers in pendingTestTags (drained on retrieval).
+ */
+exports.setCustomTag = function(keyName, keyValue, buildLevelCustomTag, testUUID) {
+  if (!keyName || !keyValue || typeof keyName !== 'string' || typeof keyValue !== 'string' ||
+      keyName.trim() === '' || keyValue.trim() === '') {
+    Logger.error('[CustomTagManager] keyName and keyValue must be non-empty strings');
+
+    return;
+  }
+
+  const values = splitValues(keyValue);
+
+  if (buildLevelCustomTag) {
+    mergeInto(buildLevelTags, keyName, values);
+
+    return;
+  }
+
+  if (!testUUID) {
+    // UUID not yet assigned — buffer and drain when the event is sent
+    mergeInto(pendingTestTags, keyName, values);
+
+    return;
+  }
+
+  if (!testLevelTags.has(testUUID)) {
+    testLevelTags.set(testUUID, {});
+  }
+  mergeInto(testLevelTags.get(testUUID), keyName, values);
+};
+
+/**
+ * Returns the custom metadata object for a specific test UUID.
+ * Also drains any pendingTestTags into this UUID's entry.
+ */
+exports.getTestLevelCustomMetadata = function(uuid) {
+  if (uuid && Object.keys(pendingTestTags).length > 0) {
+    if (!testLevelTags.has(uuid)) {
+      testLevelTags.set(uuid, {});
+    }
+    mergeAll(testLevelTags.get(uuid), pendingTestTags);
+    pendingTestTags = {};
+  }
+
+  return testLevelTags.get(uuid) || {};
+};
+
+/**
+ * Returns the build-level custom metadata object.
+ */
+exports.getBuildLevelCustomMetadata = function() {
+  return {...buildLevelTags};
+};
+
+/**
+ * Clears test-level tags for a completed test to prevent memory leaks.
+ */
+exports.clearTestLevelCustomMetadata = function(uuid) {
+  testLevelTags.delete(uuid);
+};
+
+// Exported for testing
+exports._splitValues = splitValues;
+exports._testLevelTags = testLevelTags;
+exports._buildLevelTags = buildLevelTags;
+exports._getPendingTestTags = function() { return pendingTestTags; };

--- a/src/utils/customTagManager.js
+++ b/src/utils/customTagManager.js
@@ -101,7 +101,9 @@ exports.setCustomTag = function(keyName, keyValue, buildLevelCustomTag, testUUID
  * Returns the custom metadata object for a specific test UUID.
  */
 exports.getTestLevelCustomMetadata = function(uuid) {
-  return testLevelTags.get(uuid) || {};
+  const tags = testLevelTags.get(uuid);
+
+  return tags ? JSON.parse(JSON.stringify(tags)) : {};
 };
 
 /**
@@ -123,7 +125,7 @@ exports.drainPendingTestTags = function(uuid) {
  * Returns the build-level custom metadata object.
  */
 exports.getBuildLevelCustomMetadata = function() {
-  return {...buildLevelTags};
+  return JSON.parse(JSON.stringify(buildLevelTags));
 };
 
 /**

--- a/test/src/utils/customTagManager.js
+++ b/test/src/utils/customTagManager.js
@@ -1,0 +1,78 @@
+const {expect} = require('chai');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CustomTagManager = require('../../../src/utils/customTagManager');
+
+describe('CustomTagManager', () => {
+
+  beforeEach(() => {
+    // Clear internal state between tests
+    CustomTagManager._testLevelTags.clear();
+    for (const key of Object.keys(CustomTagManager._buildLevelTags)) {
+      delete CustomTagManager._buildLevelTags[key];
+    }
+  });
+
+  describe('getTestLevelCustomMetadata', () => {
+    it('returns a deep clone, not the internal object', () => {
+      CustomTagManager.setCustomTag('env', 'staging', false, 'uuid-1');
+
+      const result = CustomTagManager.getTestLevelCustomMetadata('uuid-1');
+      // Mutate the returned object
+      result.env.values.push('production');
+
+      // Internal state should be unchanged
+      const internal = CustomTagManager.getTestLevelCustomMetadata('uuid-1');
+      expect(internal.env.values).to.deep.equal(['staging']);
+    });
+
+    it('returns empty object for unknown UUID', () => {
+      expect(CustomTagManager.getTestLevelCustomMetadata('nonexistent')).to.deep.equal({});
+    });
+  });
+
+  describe('getBuildLevelCustomMetadata', () => {
+    it('returns a deep clone, not the internal object', () => {
+      CustomTagManager.setCustomTag('release', 'v1', true, null);
+
+      const result = CustomTagManager.getBuildLevelCustomMetadata();
+      // Mutate the returned object
+      result.release.values.push('v2');
+
+      // Internal state should be unchanged
+      const internal = CustomTagManager.getBuildLevelCustomMetadata();
+      expect(internal.release.values).to.deep.equal(['v1']);
+    });
+  });
+
+  describe('temp file scoping', () => {
+    it('worker writes temp file scoped to run ID', () => {
+      // Simulate what afterChildProcess does
+      const runId = 'test-run-uuid-123';
+      const tagFile = path.join(os.tmpdir(), `bstack_build_tags_${runId}_${process.pid}.json`);
+      const tags = {env: {field_type: 'multi_dropdown', values: ['staging']}};
+      fs.writeFileSync(tagFile, JSON.stringify(tags));
+
+      // Parent reads only files matching this run
+      const tmpDir = os.tmpdir();
+      const tagFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith(`bstack_build_tags_${runId}_`) && f.endsWith('.json'));
+
+      expect(tagFiles.length).to.be.greaterThanOrEqual(1);
+      expect(tagFiles[0]).to.include(runId);
+
+      // Files from a different run should NOT be matched
+      const otherRunFile = path.join(tmpDir, `bstack_build_tags_other-run_99999.json`);
+      fs.writeFileSync(otherRunFile, JSON.stringify({}));
+
+      const matchedFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith(`bstack_build_tags_${runId}_`) && f.endsWith('.json'));
+      const hasOtherRun = matchedFiles.some(f => f.includes('other-run'));
+      expect(hasOtherRun).to.be.false;
+
+      // Cleanup
+      fs.unlinkSync(tagFile);
+      fs.unlinkSync(otherRunFile);
+    });
+  });
+});

--- a/test/src/utils/customTagManager.js
+++ b/test/src/utils/customTagManager.js
@@ -63,7 +63,7 @@ describe('CustomTagManager', () => {
       expect(tagFiles[0]).to.include(runId);
 
       // Files from a different run should NOT be matched
-      const otherRunFile = path.join(tmpDir, `bstack_build_tags_other-run_99999.json`);
+      const otherRunFile = path.join(tmpDir, 'bstack_build_tags_other-run_99999.json');
       fs.writeFileSync(otherRunFile, JSON.stringify({}));
 
       const matchedFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith(`bstack_build_tags_${runId}_`) && f.endsWith('.json'));


### PR DESCRIPTION
Expose browser.setCustomTag(keyName, keyValue, buildLevelCustomTag) to let users tag tests with custom metadata sent to TestHub. Tags with the same key are merged (not overridden). Supports both test-level and build-level metadata, comma-separated values, and pending tag buffering for calls made before the test UUID is assigned.