### PR TITLE
LTS: populate duration_in_ms + attach per-step meta.steps on Nightwatch TestRunFinished

### DIFF
--- a/nightwatch/globals.js
+++ b/nightwatch/globals.js
@@ -302,6 +302,10 @@ module.exports = {
       if (testRunner !== 'cucumber'){
         const uuid = TestMap.storeTestDetails(test);
         process.env.TEST_RUN_UUID = uuid;
+        // LTS-only: reset the per-test step buffer that bstackStep() (injected
+        // by the LCNC compiler into the compiled spec) writes into. Read back
+        // in testObservability.sendTestRunEvent at TestRunFinished.
+        if (helper.isLoadTestingSession()) {globalThis.__bstack_steps = [];}
         // Capture the live session id at TestRunStarted (when browser.end()
         // hasn't run yet). TestRunFinished's async handler can race with
         // afterEach: by the time it executes, browser.sessionId may already

--- a/src/testObservability.js
+++ b/src/testObservability.js
@@ -540,6 +540,13 @@ class TestObservability {
       // populates for LTS builds. Non-LTS emits unchanged.
       if (helper.isLoadTestingSession()) {
         testData.duration_in_ms = new Date(testData.finished_at).getTime() - new Date(testData.started_at).getTime();
+        // LTS-only: attach per-step data collected by bstackStep() (injected by
+        // the LCNC compiler into the compiled spec). Empty/absent → skip so
+        // non-instrumented specs stay backward-compatible.
+        const steps = globalThis.__bstack_steps;
+        if (Array.isArray(steps) && steps.length) {
+          testData.meta = {...(testData.meta || {}), steps};
+        }
       }
       testData.result = 'passed';
       if (eventData && eventData.commands && Array.isArray(eventData.commands)) {

--- a/src/testObservability.js
+++ b/src/testObservability.js
@@ -535,6 +535,12 @@ class TestObservability {
     if (eventType === 'TestRunFinished') {
       const eventData = test.envelope[testName].testcase;
       testData.finished_at = eventData.endTimestamp ? new Date(eventData.endTimestamp).toISOString() : new Date(startTimestamp).toISOString();
+      // LTS-only: main-path Nightwatch TestRunFinished doesn't carry duration_in_ms
+      // (cucumber/hook/skipped paths do). Compute from timestamps so BTCER duration
+      // populates for LTS builds. Non-LTS emits unchanged.
+      if (helper.isLoadTestingSession()) {
+        testData.duration_in_ms = new Date(testData.finished_at).getTime() - new Date(testData.started_at).getTime();
+      }
       testData.result = 'passed';
       if (eventData && eventData.commands && Array.isArray(eventData.commands)) {
         const failedCommand = eventData.commands.find(cmd => cmd.status === 'fail' && !helper.isSuppressedFailure(cmd));

--- a/test/src/test-observability/sendTestRunEvent.js
+++ b/test/src/test-observability/sendTestRunEvent.js
@@ -161,4 +161,31 @@ describe('TestObservability - sendTestRunEvent (suppressNotFoundErrors)', functi
       `expected failure_reason to reference the real failure, got: ${this.uploaded.test_run.failure_reason}`
     );
   });
+
+  // LTS regression: main-path Nightwatch TestRunFinished never carried
+  // duration_in_ms, leaving BTCER.duration NULL on load-testing builds and
+  // zeroing every duration-derived Tests-tab metric (min/avg/p50/p95/max).
+  // The fix computes duration from the envelope timestamps only when
+  // helper.isLoadTestingSession() is true. Non-LTS runs remain unchanged.
+  it('populates duration_in_ms from timestamps on LTS runs', async () => {
+    this.sandbox.stub(helper, 'isLoadTestingSession').returns(true);
+    const commands = [{name: 'url', args: ['https://example.com'], status: 'pass'}];
+
+    await this.testObservability.sendTestRunEvent('TestRunFinished', buildTest(commands), 'uuid-lts-1');
+
+    // Fixture: startTimestamp=1700000000000, endTimestamp=1700000001000 → 1000 ms.
+    assert.strictEqual(this.uploaded.test_run.duration_in_ms, 1000);
+  });
+
+  it('leaves duration_in_ms unset on non-LTS runs', async () => {
+    this.sandbox.stub(helper, 'isLoadTestingSession').returns(false);
+    const commands = [{name: 'url', args: ['https://example.com'], status: 'pass'}];
+
+    await this.testObservability.sendTestRunEvent('TestRunFinished', buildTest(commands), 'uuid-lts-2');
+
+    assert.ok(
+      !('duration_in_ms' in this.uploaded.test_run),
+      'expected no duration_in_ms on non-LTS runs (contract preserved)'
+    );
+  });
 });

--- a/test/src/test-observability/sendTestRunEvent.js
+++ b/test/src/test-observability/sendTestRunEvent.js
@@ -188,4 +188,51 @@ describe('TestObservability - sendTestRunEvent (suppressNotFoundErrors)', functi
       'expected no duration_in_ms on non-LTS runs (contract preserved)'
     );
   });
+
+  // LTS step-level insights: the LCNC compiler wraps each recorded step in a
+  // bstackStep() helper that pushes {id, text, duration, ...} to
+  // globalThis.__bstack_steps. sendTestRunEvent must attach that array to
+  // testData.meta.steps at TestRunFinished (only when isLoadTestingSession()
+  // is true) so the Testhub MV mv_btcer_step_metrics_v5 fans it out into the
+  // btcer_step_metrics_v5 table that Step Insights aggregates on.
+  it('attaches globalThis.__bstack_steps to meta.steps on LTS runs', async () => {
+    this.sandbox.stub(helper, 'isLoadTestingSession').returns(true);
+    const steps = [
+      {id: 'a', text: 'Open page', keyword: '', duration: 800, started_at: '2026-07-27T16:00:00.000', finished_at: '2026-07-27T16:00:00.800', result: 'passed', failure: null},
+      {id: 'b', text: 'Click X',   keyword: '', duration: 120, started_at: '2026-07-27T16:00:00.800', finished_at: '2026-07-27T16:00:00.920', result: 'passed', failure: null}
+    ];
+    globalThis.__bstack_steps = steps;
+    const commands = [{name: 'url', args: ['https://example.com'], status: 'pass'}];
+
+    try {
+      await this.testObservability.sendTestRunEvent('TestRunFinished', buildTest(commands), 'uuid-lts-steps-1');
+      assert.deepStrictEqual(this.uploaded.test_run.meta && this.uploaded.test_run.meta.steps, steps);
+    } finally {
+      delete globalThis.__bstack_steps;
+    }
+  });
+
+  it('omits meta.steps on non-LTS runs even when the buffer is populated', async () => {
+    this.sandbox.stub(helper, 'isLoadTestingSession').returns(false);
+    globalThis.__bstack_steps = [{id: 'a', text: 'Open page', duration: 800, result: 'passed'}];
+    const commands = [{name: 'url', args: ['https://example.com'], status: 'pass'}];
+
+    try {
+      await this.testObservability.sendTestRunEvent('TestRunFinished', buildTest(commands), 'uuid-lts-steps-2');
+      const meta = this.uploaded.test_run.meta;
+      assert.ok(!meta || !('steps' in meta), 'expected no meta.steps on non-LTS runs (contract preserved)');
+    } finally {
+      delete globalThis.__bstack_steps;
+    }
+  });
+
+  it('leaves meta.steps unset on LTS runs when the buffer is empty or missing', async () => {
+    this.sandbox.stub(helper, 'isLoadTestingSession').returns(true);
+    delete globalThis.__bstack_steps;
+    const commands = [{name: 'url', args: ['https://example.com'], status: 'pass'}];
+
+    await this.testObservability.sendTestRunEvent('TestRunFinished', buildTest(commands), 'uuid-lts-steps-3');
+    const meta = this.uploaded.test_run.meta;
+    assert.ok(!meta || !('steps' in meta), 'expected no meta.steps when nothing was recorded');
+  });
 });


### PR DESCRIPTION
## Summary

Two LTS-only reporting improvements to the Nightwatch main-path (`sendTestRunEvent`), both gated on `helper.isLoadTestingSession()` so non-LTS Automate customers see byte-identical uploads.

### 1. Populate `duration_in_ms` (regression fix)

Main-path Nightwatch `TestRunFinished` never carried `duration_in_ms` (cucumber / hook / skipped paths do). Downstream is a straight passthrough (observability-pipeline `EventProcessorService` L874 + L1325 in `buildBtcerForLts`), so BTCER.duration ended up NULL on every LTS Nightwatch row — every duration-derived Tests-tab metric (min/avg/p50/p75/p90/p95/p99/max) rendered as 0.

Fix: compute duration from the envelope timestamps that `sendTestRunEvent` already assigns for the `TestRunFinished` branch (`finished_at - started_at`).

### 2. Attach per-step data to `meta.steps` (new capability)

Enables the Step Insights feature for LTS Nightwatch builds. The LCNC compiler wraps every recorded step in a `bstackStep(idx, text, id, async fn)` helper that captures per-step timings and pushes `{id, text, keyword, duration, started_at, finished_at, result, failure}` to `globalThis.__bstack_steps`. This change lets the plugin surface that buffer to Testhub so the `mv_btcer_step_metrics_v5` MV fans it out into `btcer_step_metrics_v5` — the table the Step Insights `/cross-build-step-metrics` endpoint aggregates on across builds.

Two touch points:
- `nightwatch/globals.js`: reset `globalThis.__bstack_steps` on every `TestRunStarted` so retries, reruns, and per-VU iterations get clean buffers.
- `src/testObservability.js`: on `TestRunFinished`, attach the buffer to `testData.meta.steps`. Non-destructive merge — preserves whatever meta fields (e.g. `configuration_id`) the LT pipeline had already written.

## Verification

### `duration_in_ms`

Patched plugin + local Selenium jar + real Chrome + `BROWSERSTACK_LTS_SESSION_ID` set → `TestRunFinished` payload carries `duration_in_ms = 145` (matches the timestamp delta). Contract check with LTS env off → `duration_in_ms` absent from payload.

### `meta.steps` (end-to-end against real Testhub)

- Ran a sample LCNC-style Nightwatch spec (6 `bstackStep`-wrapped steps) through local chromedriver with `BROWSERSTACK_LTS_SESSION_ID=local-e2e-4` set.
- Build creation succeeded, `TestRunFinished` payload carried `test_run.meta.steps` as a 6-entry array.
- ClickHouse `build_test_case_execution_results_v5` row landed with `meta.steps` present (`length(JSONExtractArrayRaw(meta,'steps'))` = 6).
- MV `mv_btcer_step_metrics_v5` fanned out 6 rows into `btcer_step_metrics_v5` with correct `step_text`, `step_result`, `step_duration` (846, 597, 118, 72, 47, 24 ms), `step_started_at`, `step_finished_at`.

Sample build in Automate: `98w1ld2w7qqihu9mnw1brpgnv582oezqktrkpxcf` (build_id `143028133`, `source=TO,LTS`).

### Retries / re-runs

- Each Nightwatch retry attempt fires its own `TestRunStarted` → reset zeros the array → fresh 6 steps per attempt.
- Each attempt gets its own BTCER row via a distinct uuid.
- `sendTestRunEvent` captures the array reference synchronously at handler start, before any subsequent reset can happen.
- Parallel BLU pods run in separate Node processes → separate `globalThis` → no cross-pollination.

## Test plan

- [x] Unit tests added to `test/src/test-observability/sendTestRunEvent.js`:
  - `duration_in_ms` populated on LTS runs (existing from prior commit)
  - `duration_in_ms` unset on non-LTS runs (existing from prior commit)
  - `meta.steps` attached on LTS runs when buffer populated
  - `meta.steps` omitted on non-LTS runs even when buffer populated
  - `meta.steps` omitted on LTS runs when buffer empty/missing
- [x] Local end-to-end mimic against real Testhub — see Verification section.
- [ ] Full LTS pod run against a Playwright/Selenium-generated LCNC test (deferred — pairs with the matching LCNC compiler PR that emits `bstackStep(...)` wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)